### PR TITLE
fix(environment): WeakHashMap 迭代被 GC 打断抛异常，导致环境回调失败

### DIFF
--- a/app/src/main/kotlin/io/github/mangi/flymefreeform/hook/OutsideTapCloseHookInstaller.kt
+++ b/app/src/main/kotlin/io/github/mangi/flymefreeform/hook/OutsideTapCloseHookInstaller.kt
@@ -197,7 +197,18 @@ internal class OutsideTapCloseHookInstaller(
             settings: io.github.mangi.flymefreeform.config.ModuleSettingsSnapshot,
         ) {
             interruptAll()
-            val knownCaptions = synchronized(captions) { captions.keys.toList() }
+            // WeakHashMap 在迭代期间若发生 GC，`getTable()` 会顺手 expunge 掉失效条目，
+            // 迭代器会提前 nextEntry() 失败抛 NoSuchElementException；取到多少就刷新多少。
+            val knownCaptions =
+                synchronized(captions) {
+                    val snapshot = ArrayList<Any>(captions.size)
+                    try {
+                        captions.keys.forEach { caption -> snapshot += caption }
+                    } catch (_: NoSuchElementException) {
+                        // 已收集到的条目足够继续刷新，剩余条目会在下次回调处理。
+                    }
+                    snapshot
+                }
             knownCaptions.forEach { caption ->
                 try {
                     updateCaptionTouchRegion.invokeUnwrapped(caption)


### PR DESCRIPTION
## 问题

`OutsideTapCloseHookInstaller.ColorOsOutsideTapAccess.onConfigurationChanged` 在遍历 `WeakHashMap` 时会抛异常：

```
java.util.NoSuchElementException
    at java.util.WeakHashMap$HashIterator.nextEntry(WeakHashMap.java:817)
    at io.github.mangi.flymefreeform.hook.OutsideTapCloseHookInstaller$ColorOsOutsideTapAccess.onConfigurationChanged(OutsideTapCloseHookInstaller.kt:200)
    at io.github.mangi.flymefreeform.hook.ModuleEnvironmentState.notifyIfChanged(ModuleEnvironmentState.kt:179)
    at io.github.mangi.flymefreeform.hook.ModuleEnvironmentState$lockReceiver$1.onReceive(ModuleEnvironmentState.kt:65)
```

原因不是线程安全（`captions` 的读写本来就在同一把锁里），而是 `WeakHashMap` 的固有行为：迭代期间若发生 GC，`getTable()` 会顺手 expunge 掉失效条目，迭代器可能直接 `nextEntry()` 失败并抛 `NoSuchElementException`（不是 `ConcurrentModificationException`）。异常虽然被 `notifyIfChanged()` 的逐观察者 try/catch 兜住，但这一次的刷新会中断。

## 现象（真机）

出现过一次"**扇形再也划不出来**"：launcher 侧仍然 claim 角落手势，但 system_server 侧没有任何门控或启动日志——手势在门控判断处被静默拦下。门控是 fail-safe 的（`gestureNavigation` 读失败变 `false`、`gameModeActive` 读失败变 `true`、`keyguardLocked` 取不到变 `true`），任何一项异常都会把扇形静默关掉，所以现场没有任何报错可看。

## 改动

同一把锁内做防御性快照，迭代被 GC 打断时保留已取到的条目：

```kotlin
val knownCaptions = synchronized(captions) {
    val snapshot = ArrayList<Any>(captions.size)
    try {
        captions.keys.forEach { caption -> snapshot += caption }
    } catch (_: NoSuchElementException) {
        // 已收集到的条目足够继续刷新，剩余条目会在下次回调处理。
    }
    snapshot
}
```

## 验证状态：**未验证**

这份改动**没有经过确认**。真机上出现上述异常后重启（软重启）模块，问题不再复现——但无法区分是这次修复生效，还是重启本身恢复了状态。因此请作者或有条件复核的人按下面方式验证后再合入。

## 建议的复核方式

1. 使用模块一段时间并反复锁屏/亮屏，确认 LSPosed 日志里不再出现 `MODULE_ENVIRONMENT_CALLBACK_FAILED`；
2. 若仍然出现，请回帖附上堆栈，我再补一轮。

另外：定位过程中我在 `ColorOsFreeformCoordinator` 里加了几行"手势被拦就打印门控各项取值"的诊断日志（`GESTURE_BLOCKED` / `GESTURE_DISABLED`，按 3 秒节流）。它和 #1 会改同一个文件，为避免冲突没有放进这个 PR；如果需要，我可以单独整理成一个小改动。
